### PR TITLE
7 Time Format Setting

### DIFF
--- a/src/net/sf/memoranda/ui/EventDialog.java
+++ b/src/net/sf/memoranda/ui/EventDialog.java
@@ -37,7 +37,9 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 import net.sf.memoranda.date.CalendarDate;
+import net.sf.memoranda.util.Configuration;
 import net.sf.memoranda.util.Local;
+import net.sf.memoranda.util.Util;
 
 /*$Id: EventDialog.java,v 1.28 2005/02/19 10:06:25 rawsushi Exp $*/
 public class EventDialog extends JDialog implements WindowListener {	
@@ -113,7 +115,7 @@ public class EventDialog extends JDialog implements WindowListener {
         gbc.insets = new Insets(10, 10, 5, 10);
         gbc.anchor = GridBagConstraints.WEST;
         eventPanel.add(lblTime, gbc);
-        timeSpin.setPreferredSize(new Dimension(60, 24));
+        timeSpin.setPreferredSize(new Dimension(70, 24));
         gbc = new GridBagConstraints();
         gbc.gridx = 1; gbc.gridy = 0;
         gbc.insets = new Insets(10, 0, 5, 0);
@@ -404,7 +406,17 @@ public class EventDialog extends JDialog implements WindowListener {
             }
         });
         disableElements();
-        ((JSpinner.DateEditor) timeSpin.getEditor()).getFormat().applyPattern("HH:mm");
+        
+        /*
+         * Adjust time spinner to reflect user time format preference
+         */
+   		String timeform = Configuration.get("TIME_FORMAT").toString();
+   		if (timeform.equalsIgnoreCase("military")){
+   			((JSpinner.DateEditor) timeSpin.getEditor()).getFormat().applyPattern("HH:mm"); 
+   		}
+   		else{
+   			((JSpinner.DateEditor) timeSpin.getEditor()).getFormat().applyPattern("hh:mm aa");
+   		}
         enableEndDateCB_actionPerformed(null);
         
     }

--- a/src/net/sf/memoranda/ui/EventNotificationDialog.java
+++ b/src/net/sf/memoranda/ui/EventNotificationDialog.java
@@ -16,6 +16,7 @@ import javax.swing.border.Border;
 
 import net.sf.memoranda.util.Configuration;
 import net.sf.memoranda.util.Local;
+import net.sf.memoranda.util.Util;
 
 import java.applet.Applet;
 import java.applet.AudioClip;
@@ -46,6 +47,12 @@ public class EventNotificationDialog extends JFrame {
     catch(Exception ex) {
       new ExceptionDialog(ex);
     }
+    /*
+     * Adjust how time is shown in event notification "pop up", based on user time format preference
+     */
+	if(Configuration.get("TIME_FORMAT").toString().equalsIgnoreCase("military")){
+		time = Util.getMilitaryTime(time);
+	}
     timeLabel.setText(time);
     timeLabel.setIcon(new ImageIcon(net.sf.memoranda.ui.TaskDialog.class.getResource(
             "resources/icons/event48.png")));

--- a/src/net/sf/memoranda/ui/EventsTable.java
+++ b/src/net/sf/memoranda/ui/EventsTable.java
@@ -22,7 +22,9 @@ import net.sf.memoranda.EventsManager;
 import net.sf.memoranda.date.CalendarDate;
 import net.sf.memoranda.date.CurrentDate;
 import net.sf.memoranda.date.DateListener;
+import net.sf.memoranda.util.Configuration;
 import net.sf.memoranda.util.Local;
+import net.sf.memoranda.util.Util;
 /**
  *
  */
@@ -50,7 +52,6 @@ public class EventsTable extends JTable {
     }
 
     public void initTable(CalendarDate d) {
-    	this.setAutoCreateRowSorter(true);
         events = (Vector)EventsManager.getEventsForDate(d);
         getColumnModel().getColumn(0).setPreferredWidth(60);
         getColumnModel().getColumn(0).setMaxWidth(60);
@@ -123,9 +124,19 @@ public class EventsTable extends JTable {
 
         public Object getValueAt(int row, int col) {
            Event ev = (Event)events.get(row);
-           if (col == 0)
+           if (col == 0){
                 //return ev.getHour()+":"+ev.getMinute();
-                return ev.getTimeString();
+        	   
+        	   	/*
+        	   	 * Return time String based on user preference
+        	   	 */
+	       		String timeform = Configuration.get("TIME_FORMAT").toString();
+	       		if (timeform.equalsIgnoreCase("military")){
+	       			return Util.getMilitaryTime(ev.getTimeString());
+	       		}
+	       		else   	   	
+	       			return ev.getTimeString();
+           }     
            else if (col == 1)
                 return ev.getText();
            else if (col == EVENT_ID)

--- a/src/net/sf/memoranda/ui/PreferencesDialog.java
+++ b/src/net/sf/memoranda/ui/PreferencesDialog.java
@@ -3,10 +3,14 @@ package net.sf.memoranda.ui;
 import java.io.File;
 import java.util.Vector;
 
+import net.sf.memoranda.date.CurrentDate;
+import net.sf.memoranda.util.AgendaGenerator;
 import net.sf.memoranda.util.Configuration;
 import net.sf.memoranda.util.CurrentStorage;
 import net.sf.memoranda.util.Local;
 import net.sf.memoranda.util.MimeTypesList;
+import net.sf.memoranda.util.Util;
+
 import java.awt.*;
 
 import javax.swing.*;
@@ -30,7 +34,15 @@ public class PreferencesDialog extends JDialog {
 	JRadioButton minTaskbarRB = new JRadioButton();
 
 	JRadioButton minHideRB = new JRadioButton();
+	
+	JRadioButton standardTimeRB = new JRadioButton();
 
+	JRadioButton militaryTimeRB = new JRadioButton();
+	
+	ButtonGroup timeGroup = new ButtonGroup();
+	
+	JLabel jLabel7 = new JLabel();
+	
 	ButtonGroup closeGroup = new ButtonGroup();
 
 	JLabel jLabel2 = new JLabel();
@@ -195,6 +207,7 @@ public class PreferencesDialog extends JDialog {
 		jPanel2.setLayout(borderLayout2);
 		soundPanel.add(jPanel2, BorderLayout.CENTER);
 		jPanel2.add(jPanel1, BorderLayout.NORTH);
+		
 		jPanel1.add(soundDefaultRB, null);
 		jPanel1.add(soundBeepRB, null);
 		jPanel1.add(soundCustomRB, null);
@@ -280,7 +293,7 @@ public class PreferencesDialog extends JDialog {
 
 		gbc = new GridBagConstraints();
 		gbc.gridx = 1;
-		gbc.gridy = 4;
+		gbc.gridy = 4; 
 		gbc.insets = new Insets(2, 0, 0, 10);
 		gbc.anchor = GridBagConstraints.WEST;
 
@@ -409,6 +422,55 @@ public class PreferencesDialog extends JDialog {
 		gbc.insets = new Insets(2, 0, 10, 10);
 		gbc.anchor = GridBagConstraints.WEST;
 		GeneralPanel.add(askConfirmChB, gbc);
+		
+		/*
+		 * Time format setting added to preferences
+		 * 
+		 * Victor Best 1/2016
+		 */
+		gbc = new GridBagConstraints();
+		gbc.gridx = 1;
+		gbc.gridy = 16;
+		gbc.insets = new Insets(2, 0, 0, 10);
+		gbc.anchor = GridBagConstraints.WEST;
+		GeneralPanel.add(standardTimeRB, gbc);
+		jLabel7.setHorizontalAlignment(SwingConstants.RIGHT);
+		jLabel7.setText(Local.getString("Time format:"));
+		
+		gbc = new GridBagConstraints();
+		gbc.gridx = 0;
+		gbc.gridy = 17;
+		gbc.insets = new Insets(2, 10, 0, 15);
+		gbc.anchor = GridBagConstraints.EAST;
+		GeneralPanel.add(jLabel7, gbc);
+		timeGroup.add(standardTimeRB);
+		standardTimeRB.setSelected(true);
+		standardTimeRB.setText(Local.getString("12 Hour"));
+		standardTimeRB.addActionListener(new java.awt.event.ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				standardTimeRB_actionPerformed(e);
+			}
+		});
+		gbc = new GridBagConstraints();
+		gbc.gridx = 1;
+		gbc.gridy = 17;
+		gbc.insets = new Insets(2, 0, 0, 10);
+		gbc.anchor = GridBagConstraints.WEST;
+		GeneralPanel.add(standardTimeRB, gbc);
+
+		timeGroup.add(militaryTimeRB);
+		militaryTimeRB.setText(Local.getString("24 Hour"));
+		militaryTimeRB.addActionListener(new java.awt.event.ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				militaryTimeRB_actionPerformed(e);
+			}
+		});
+		gbc = new GridBagConstraints();
+		gbc.gridx = 1;
+		gbc.gridy = 18;
+		gbc.insets = new Insets(2, 0, 0, 10);
+		gbc.anchor = GridBagConstraints.WEST;
+		GeneralPanel.add(militaryTimeRB, gbc);
 
 		// Build Tab2
 		rstPanelBorder = BorderFactory.createEmptyBorder(5, 5, 5, 5);
@@ -491,6 +553,13 @@ public class PreferencesDialog extends JDialog {
 				.toString().equalsIgnoreCase("yes"));
 		firstdow.setSelected(Configuration.get("FIRST_DAY_OF_WEEK").toString()
 				.equalsIgnoreCase("mon"));
+		
+		String timeform = Configuration.get("TIME_FORMAT").toString();
+		System.out.println("TimeForm:" + timeform);
+		if (timeform.equalsIgnoreCase("standard"))
+			standardTimeRB.setSelected(true);
+		else if (timeform.equalsIgnoreCase("military"))
+			militaryTimeRB.setSelected(true);
 
 		enableCustomLF(false);
 		String lf = Configuration.get("LOOK_AND_FEEL").toString();
@@ -566,6 +635,12 @@ public class PreferencesDialog extends JDialog {
 	}
 
 	void apply() {
+		
+		if (this.standardTimeRB.isSelected())
+			Configuration.put("TIME_FORMAT", "standard");
+		else
+			Configuration.put("TIME_FORMAT", "military");
+		
 		if (this.firstdow.isSelected())
 			Configuration.put("FIRST_DAY_OF_WEEK", "mon");
 		else
@@ -659,6 +734,8 @@ public class PreferencesDialog extends JDialog {
 		App.getFrame().workPanel.dailyItemsPanel.editorPanel.editor.editor.setAntiAlias(antialiasChB.isSelected());
 		App.getFrame().workPanel.dailyItemsPanel.editorPanel.initCSS();
 		App.getFrame().workPanel.dailyItemsPanel.editorPanel.editor.repaint();
+		App.getFrame().workPanel.dailyItemsPanel.agendaPanel.refresh(CurrentDate.get());
+		App.getFrame().workPanel.dailyItemsPanel.eventsPanel.updateUI();
 		
 		Configuration.saveConfig();
 		
@@ -674,6 +751,7 @@ public class PreferencesDialog extends JDialog {
 		this.soundFileBrowseB.setEnabled(is);
 		this.jLabel6.setEnabled(is);
 	}
+	
 
 	void enableSound(boolean is) {
 		this.soundDefaultRB.setEnabled(is);
@@ -706,6 +784,14 @@ public class PreferencesDialog extends JDialog {
 
 	void closeExitRB_actionPerformed(ActionEvent e) {
 		// this.askConfirmChB.setEnabled(true);
+	}
+	
+	void standardTimeRB_actionPerformed(ActionEvent e) {
+		//System.out.println("standard time selected");		
+	}
+	
+	void militaryTimeRB_actionPerformed(ActionEvent e) {
+		//System.out.println("military time selected");	
 	}
 
 	void askConfirmChB_actionPerformed(ActionEvent e) {

--- a/src/net/sf/memoranda/util/AgendaGenerator.java
+++ b/src/net/sf/memoranda/util/AgendaGenerator.java
@@ -338,6 +338,16 @@ public class AgendaGenerator {
 							.toExternalForm();
 				}
 			}
+			/*
+			 * Format time String based on user preference
+			 * 
+			 * Victor 1/2016
+			 */
+			String timeString = e.getTimeString();
+			if(Configuration.get("TIME_FORMAT").toString().equalsIgnoreCase("military")){
+				timeString = Util.getMilitaryTime(e.getTimeString());
+			}
+			
 			String icon =
 					"<img align=\"right\" width=\"16\" height=\"16\" src=\""
 							+ iurl
@@ -347,7 +357,7 @@ public class AgendaGenerator {
 					+ icon
 					+ "</td>"
 					+ "<td nowrap class=\"eventtime\">"
-					+ e.getTimeString()
+					+ timeString
 					+ "</td>"
 					+ "<td width=\"100%\" class=\"eventtext\">&nbsp;&nbsp;"
 					+ "<a href=\"memoranda:events\"><b>"

--- a/src/net/sf/memoranda/util/Util.java
+++ b/src/net/sf/memoranda/util/Util.java
@@ -44,7 +44,33 @@ public class Util {
 				"-"+Integer.toString(r.nextInt(65535), 16);
                     
     }
-
+    
+    /*
+     * Used for converting a time String of Format "hh:mm aa" to 24 hour 
+     * time String of format "HH:mm"
+     * 
+     * Victor Best 1/2016
+     */
+    public static String getMilitaryTime(String time){
+    	
+    	if(time.length() == 0){
+    		return time;
+    	}
+    	
+    	String milTime = "";   	
+    	String hours = time.substring(0, time.indexOf(":"));
+    	String minutes = time.substring((time.indexOf(":") + 1), (time.length() - 2));
+    	
+    	int hrs = Integer.parseInt(hours);
+    	
+    	if(time.contains("PM")){
+    		hrs += 12;
+    	}
+    	
+    	milTime = hrs + ":" + minutes;
+    	return milTime;
+    }
+    
     public static String getDateStamp(Calendar cal) {
         return cal.get(Calendar.DAY_OF_MONTH)
             + "/"

--- a/src/net/sf/memoranda/util/resources/memoranda.default.properties
+++ b/src/net/sf/memoranda/util/resources/memoranda.default.properties
@@ -30,5 +30,8 @@ START_MINIMIZED = no
 
 PORT_NUMBER = 19432
 
+# Time format setting
+TIME_FORMAT = standard
+
 CHECK_IF_ALREADY_STARTED = YES
 


### PR DESCRIPTION
Added code to allow user to select time format in preferences. User can choose between 12hr and 24hr time format. Changes will be instantly displayed on:

The Events Table on the Home/Agenda page
The Events Viewer Page (Time column)
The Edit Events Dialog (when choosing an event time)
The New Events Dialog (when choosing an event time)
On Event Notifications

Changes will not be shown on stickers as we discussed removing the date from those all together.
