### PR TITLE
US-48 Fix Minimization and Close to System Tray

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Sat Jan 30 17:05:09 MST 2016
-build.number=41
+#Mon Feb 08 16:50:05 MST 2016
+build.number=46

--- a/src/net/sf/memoranda/ui/App.java
+++ b/src/net/sf/memoranda/ui/App.java
@@ -138,12 +138,33 @@ public class App {
 
 	}
 
+	/*
+	 * close window completely
+	 */
 	public static void closeWindow() {
 		if (frame == null)
 			return;
 		frame.dispose();
 	}
-
+	
+	/*
+	 * minimize window to system tray
+	 */
+	public static void minimizeWindow() {
+		if (frame == null)
+			return;
+		frame.setState(Frame.ICONIFIED);
+	}
+	
+	/*
+	 * Reopen window when minimized to system tray
+	 */
+	public static void reOpenWindow() {
+		if (frame == null)
+			return;
+		frame.setState(Frame.NORMAL);
+	}	
+	
 	/**
 	 * Method showSplash.
 	 */

--- a/src/net/sf/memoranda/ui/AppFrame.java
+++ b/src/net/sf/memoranda/ui/AppFrame.java
@@ -1,13 +1,22 @@
 package net.sf.memoranda.ui;
 
 import java.awt.AWTEvent;
+import java.awt.AWTException;
 import java.awt.BorderLayout;
+import java.awt.CheckboxMenuItem;
 import java.awt.Dimension;
 import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuItem;
 import java.awt.Point;
+import java.awt.PopupMenu;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowEvent;
 import java.io.File;
@@ -27,6 +36,7 @@ import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JSplitPane;
 import javax.swing.JToolBar;
@@ -664,9 +674,18 @@ public class AppFrame extends JFrame {
         System.exit(0);
     }
 
+    /*
+     * Minimize window to system tray
+     */
     public void doMinimize() {
-        exitNotify();
-        App.closeWindow();
+        App.minimizeWindow();
+    }
+    
+    /*
+     * Maximize window from system tray
+     */
+    public void doMaximize() {
+        App.reOpenWindow();
     }
 
     //Help | About action performed
@@ -682,18 +701,65 @@ public class AppFrame extends JFrame {
 
     protected void processWindowEvent(WindowEvent e) {
         if (e.getID() == WindowEvent.WINDOW_CLOSING) {
-            if (Configuration.get("ON_CLOSE").equals("exit"))
-                doExit();
-            else
-                doMinimize();
+            if (Configuration.get("ON_CLOSE").equals("exit")){
+            	doExit();   	
+            }
+            else{
+            	addSystemTrayIcon();
+            	doMinimize();
+            }
         }
-        else if ((e.getID() == WindowEvent.WINDOW_ICONIFIED)) {
-            super.processWindowEvent(new WindowEvent(this,
-                    WindowEvent.WINDOW_CLOSING));
-            doMinimize();
-        }
-        else
+        else 
             super.processWindowEvent(e);
+    }
+    
+    /*
+     * Create system tray icon, with open exit option
+     */
+    public void addSystemTrayIcon(){
+    	
+    	//Check the SystemTray is supported
+        if (!SystemTray.isSupported()) {
+            System.out.println("SystemTray is not supported");
+            return;
+        }
+        final PopupMenu popup = new PopupMenu();
+        final TrayIcon trayIcon = new TrayIcon(new ImageIcon(AppFrame.class.getResource("resources/icons/date.png")).getImage());
+        final SystemTray tray = SystemTray.getSystemTray();
+        trayIcon.setToolTip("Memoranda");
+       
+        //Create a popup menu components
+        MenuItem openItem = new MenuItem("Open");
+        MenuItem exitItem = new MenuItem("Exit");
+         
+        //Add components to popup menu
+        popup.add(openItem);
+        popup.addSeparator();  
+        popup.add(exitItem);
+         
+        trayIcon.setPopupMenu(popup);
+         
+        try {
+            tray.add(trayIcon);
+        } catch (AWTException e) {
+            System.out.println("TrayIcon could not be added.");
+            return;
+        }
+      
+        exitItem.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                tray.remove(trayIcon);
+                System.exit(0);
+            }
+        });
+        
+        openItem.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                tray.remove(trayIcon);
+                doMaximize();
+            }
+        });
+        
     }
 
     public static void addExitListener(ActionListener al) {

--- a/src/net/sf/memoranda/ui/PreferencesDialog.java
+++ b/src/net/sf/memoranda/ui/PreferencesDialog.java
@@ -111,14 +111,8 @@ public class PreferencesDialog extends JDialog {
 				Color.white, new Color(156, 156, 158)), Local
 				.getString("Sound"));
 		this.setResizable(false);
+		
 		// Build Tab1
-		jLabel1.setHorizontalAlignment(SwingConstants.RIGHT);
-		jLabel1.setText(Local.getString("Window minimize action:"));
-		gbc = new GridBagConstraints();
-		gbc.gridx = 0;
-		gbc.gridy = 0;
-		gbc.insets = new Insets(10, 10, 0, 15);
-		gbc.anchor = GridBagConstraints.EAST;
 		enableSoundCB.setText(Local.getString("Enable sound notifications"));
 		enableSoundCB.addActionListener(new java.awt.event.ActionListener() {
 			public void actionPerformed(ActionEvent e) {
@@ -169,36 +163,8 @@ public class PreferencesDialog extends JDialog {
 		jPanel3.add(soundFile, BorderLayout.CENTER);
 		jPanel3.add(soundFileBrowseB, BorderLayout.EAST);
 		jPanel3.add(jLabel6, BorderLayout.WEST);
-		GeneralPanel.add(jLabel1, gbc);
-		minGroup.add(minTaskbarRB);
-		minTaskbarRB.setSelected(true);
-		minTaskbarRB.setText(Local.getString("Minimize to taskbar"));
-		minTaskbarRB.addActionListener(new java.awt.event.ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				minTaskbarRB_actionPerformed(e);
-			}
-		});
-		gbc = new GridBagConstraints();
-		gbc.gridx = 1;
-		gbc.gridy = 0;
-		gbc.insets = new Insets(10, 0, 0, 10);
-		gbc.anchor = GridBagConstraints.WEST;
-		GeneralPanel.add(minTaskbarRB, gbc);
-		minGroup.add(minHideRB);
-		minHideRB.setText(Local.getString("Hide"));
-		minHideRB.addActionListener(new java.awt.event.ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				minHideRB_actionPerformed(e);
-			}
-		});
-		gbc = new GridBagConstraints();
-		gbc.gridx = 1;
-		gbc.gridy = 1;
-		gbc.insets = new Insets(2, 0, 0, 10);
-		gbc.anchor = GridBagConstraints.WEST;
-		GeneralPanel.add(minHideRB, gbc);
 		jLabel2.setHorizontalAlignment(SwingConstants.RIGHT);
-		jLabel2.setText(Local.getString("Window close action:"));
+		jLabel2.setText(Local.getString("Window close action:"));  
 		gbc = new GridBagConstraints();
 		gbc.gridx = 0;
 		gbc.gridy = 2;
@@ -221,7 +187,7 @@ public class PreferencesDialog extends JDialog {
 		GeneralPanel.add(closeExitRB, gbc);
 
 		closeGroup.add(closeHideRB);
-		closeHideRB.setText(Local.getString("Hide"));
+		closeHideRB.setText(Local.getString("Minimize to system tray"));
 		closeHideRB.addActionListener(new java.awt.event.ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				closeHideRB_actionPerformed(e);

--- a/src/net/sf/memoranda/ui/PreferencesDialog.java
+++ b/src/net/sf/memoranda/ui/PreferencesDialog.java
@@ -488,8 +488,22 @@ public class PreferencesDialog extends JDialog {
 		// Build Tab2
 		rstPanelBorder = BorderFactory.createEmptyBorder(5, 5, 5, 5);
 		resourceTypePanel.setBorder(rstPanelBorder);
-		resourcePanel.add(resourceTypePanel, BorderLayout.CENTER);
 		
+		JButton resourceSelector = new JButton();
+		resourceSelector.setText("Choose resource location");
+		resourceSelector.addActionListener(new java.awt.event.ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				JFileChooser picker = new JFileChooser();
+				picker.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+				picker.showOpenDialog(picker);
+				File chosen = picker.getSelectedFile();
+				Configuration.put("RESOURCE_PATH", chosen.toString());
+			}
+		});
+		
+		
+		
+		resourcePanel.add(resourceSelector);
 		// Build editorConfigPanel
 		normalFontLabel.setText(Local.getString("Normal text font"));
 		normalFontLabel.setHorizontalAlignment(SwingConstants.RIGHT);

--- a/src/net/sf/memoranda/ui/WorkPanel.java
+++ b/src/net/sf/memoranda/ui/WorkPanel.java
@@ -231,21 +231,7 @@ public class WorkPanel extends JPanel {
 			else if (pan.equals("EVENTS"))
 				eventsB_actionPerformed(null);
 			else if (pan.equals("FILES")) {
-				if (Configuration.get("RESOURCE_PATH").equals("nothing")) {
-					JFileChooser picker = new JFileChooser();
-					picker.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-					picker.showOpenDialog(picker);
-					File chosen = picker.getSelectedFile();
-					Configuration.put("RESOURCE_PATH", chosen.toString());
-				}
-				if(isWindows()){
-					try {
-						Desktop.getDesktop().open(new File((String) Configuration.get("RESOURCE_PATH")));
-					} catch (IOException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}
-				}
+					filesB_actionPerformed(null);
 			}
 		}
 	}

--- a/src/net/sf/memoranda/ui/WorkPanel.java
+++ b/src/net/sf/memoranda/ui/WorkPanel.java
@@ -3,19 +3,24 @@ package net.sf.memoranda.ui;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Color;
+import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.IOException;
 
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
+import javax.swing.JFileChooser;
 import javax.swing.JPanel;
 import javax.swing.JToolBar;
 import javax.swing.SwingConstants;
 import javax.swing.border.BevelBorder;
 import javax.swing.border.Border;
 
+import net.sf.memoranda.util.Configuration;
 import net.sf.memoranda.util.Context;
 import net.sf.memoranda.util.Local;
 
@@ -225,9 +230,32 @@ public class WorkPanel extends JPanel {
 				tasksB_actionPerformed(null);
 			else if (pan.equals("EVENTS"))
 				eventsB_actionPerformed(null);
-			else if (pan.equals("FILES"))
-				filesB_actionPerformed(null);
+			else if (pan.equals("FILES")) {
+				if (Configuration.get("RESOURCE_PATH").equals("nothing")) {
+					JFileChooser picker = new JFileChooser();
+					picker.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+					picker.showOpenDialog(picker);
+					File chosen = picker.getSelectedFile();
+					Configuration.put("RESOURCE_PATH", chosen.toString());
+				}
+				if(isWindows()){
+					try {
+						Desktop.getDesktop().open(new File((String) Configuration.get("RESOURCE_PATH")));
+					} catch (IOException e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
+				}
+			}
 		}
+	}
+	
+	public static boolean isWindows() {
+
+	    String os = System.getProperty("os.name").toLowerCase();
+	    // windows
+	    return (os.indexOf("win") >= 0);
+
 	}
 
 	public void agendaB_actionPerformed(ActionEvent e) {
@@ -259,9 +287,21 @@ public class WorkPanel extends JPanel {
 	}
 
 	public void filesB_actionPerformed(ActionEvent e) {
-		cardLayout1.show(panel, "FILES");
-		setCurrentButton(filesB);
-		Context.put("CURRENT_PANEL", "FILES");
+		if (Configuration.get("RESOURCE_PATH").equals("nothing")) {
+			JFileChooser picker = new JFileChooser();
+			picker.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+			picker.showOpenDialog(picker);
+			File chosen = picker.getSelectedFile();
+			Configuration.put("RESOURCE_PATH", chosen.toString());
+		}
+		if(isWindows()){
+			try {
+				Desktop.getDesktop().open(new File((String) Configuration.get("RESOURCE_PATH")));
+			} catch (IOException exc) {
+				// TODO Auto-generated catch block
+				exc.printStackTrace();
+			}
+		}
 	}
 
 	void setCurrentButton(JButton cb) {

--- a/src/net/sf/memoranda/util/resources/memoranda.default.properties
+++ b/src/net/sf/memoranda/util/resources/memoranda.default.properties
@@ -41,3 +41,7 @@ CALC_EFFORT = yes
 COMPACT_DATES = yes
 CALC_COMPLETION = yes
 
+
+# Resource root folder
+RESOURCE_PATH = nothing
+


### PR DESCRIPTION
Removed, minimize options from preferences, minimize works as expected.
Updated close options in preferences, user can choose to close and exit as usual, or close to the system tray
- If the user selects close to "close to system tray" in preferences, when the close button is hit       Memoranda closes to an icon on the stem tray. The user can then either right click on that icon and choose "open" to reopen the window, or "exit" to close the program completely.
