### PR TITLE
US-25 create project auto-switch functionality

### DIFF
--- a/src/net/sf/memoranda/ui/AppFrame.java
+++ b/src/net/sf/memoranda/ui/AppFrame.java
@@ -673,6 +673,20 @@ public class AppFrame extends JFrame {
     }
 
     /*
+     * Prompt user if to auto-switch to new project
+     */
+    public void doNewProject() {
+        if (Configuration.get("ASK_ON_NEW").equals("yes")) {
+                        Dimension frmSize = this.getSize();
+                        Point loc = this.getLocation();
+                        
+                        AutoSwitchProjectsConfirmationDialog dlg = new AutoSwitchProjectsConfirmationDialog(this,Local.getString("Notice"));
+                        dlg.setLocation((frmSize.width - dlg.getSize().width) / 2 + loc.x, (frmSize.height - dlg.getSize().height) / 2 + loc.y);
+                        dlg.setVisible(true);
+        }
+    }
+    
+    /*
      * Minimize window to system tray
      */
     public void doMinimize() {

--- a/src/net/sf/memoranda/ui/AutoSwitchProjectsConfirmationDialog.java
+++ b/src/net/sf/memoranda/ui/AutoSwitchProjectsConfirmationDialog.java
@@ -1,0 +1,127 @@
+package net.sf.memoranda.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.event.ActionEvent;
+
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
+import net.sf.memoranda.util.Local;
+import net.sf.memoranda.util.Configuration;
+
+@SuppressWarnings("serial")
+public class AutoSwitchProjectsConfirmationDialog extends JDialog{
+    
+	public JLabel header = new JLabel();
+	JPanel headerPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+	JPanel bottomPanel = new JPanel(new BorderLayout());
+	
+    JPanel buttonsPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 10));
+    JButton yesB = new JButton();
+    JButton noB = new JButton();
+	
+	public JCheckBox donotaskCB = new JCheckBox();
+	
+	JPanel mainPanel = new JPanel(new BorderLayout());
+	
+    public AutoSwitchProjectsConfirmationDialog(Frame frame, String title) {
+       super(frame, title, true);
+       try {
+           jbInit();
+           pack();
+       }
+       catch (Exception ex) {
+           new ExceptionDialog(ex);
+       }
+    }
+
+	void jbInit() throws Exception {
+		this.setResizable(false);
+        
+		// Build headerPanel
+        headerPanel.setBackground(Color.WHITE);
+        headerPanel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+        header.setFont(new java.awt.Font("Dialog", 0, 20));
+        header.setForeground(new Color(0, 0, 124));
+        header.setText(Local.getString("NOTICE"));
+        header.setIcon(new ImageIcon(net.sf.memoranda.ui.EventDialog.class.getResource(
+            "resources/icons/pr_highest.png")));
+        headerPanel.add(header);
+		
+		// Build mainPanel
+		JLabel confirm = new JLabel();
+		confirm.setText("<HTML>"+Local.getString("Do you want to automatically switch to new projects?"));
+										
+		donotaskCB.setText(Local.getString("do not ask again"));
+		donotaskCB.setHorizontalAlignment(SwingConstants.CENTER);
+		
+		mainPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+		mainPanel.add(donotaskCB,BorderLayout.SOUTH);
+		mainPanel.add(confirm,BorderLayout.CENTER);
+		
+	    // Build ButtonsPanel
+        yesB.setMaximumSize(new Dimension(100, 26));
+        yesB.setMinimumSize(new Dimension(100, 26));
+        yesB.setPreferredSize(new Dimension(100, 26));
+        yesB.setText(Local.getString("Yes"));
+        yesB.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                yesB_actionPerformed(e);
+            }
+        });
+        this.getRootPane().setDefaultButton(yesB);
+        noB.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                noB_actionPerformed(e);
+            }
+        });
+        noB.setText(Local.getString("No"));
+        noB.setPreferredSize(new Dimension(100, 26));
+        noB.setMinimumSize(new Dimension(100, 26));
+        noB.setMaximumSize(new Dimension(100, 26));
+        buttonsPanel.add(yesB);
+        buttonsPanel.add(noB);
+		bottomPanel.add(buttonsPanel, BorderLayout.SOUTH);
+		
+		this.getRootPane().setDefaultButton(yesB);
+		
+		// Build dialog
+		this.getContentPane().add(mainPanel, BorderLayout.CENTER);
+		this.getContentPane().add(headerPanel, BorderLayout.NORTH);
+		this.getContentPane().add(bottomPanel, BorderLayout.SOUTH);
+	}
+	
+	// if donotaskCB is checked update Configuration.
+	public void  checkDoNotAsk() {
+		if (this.donotaskCB.isSelected()) {
+			Configuration.put("ASK_ON_NEW", "no");
+			Configuration.saveConfig();
+		}
+	}
+	
+	//yes button action
+    void yesB_actionPerformed(ActionEvent e) {
+		checkDoNotAsk();
+		Configuration.put("AUTO_SWITCH_PROJECT", "yes");
+        this.dispose();
+    }
+
+	//cancel button action
+    void noB_actionPerformed(ActionEvent e) {
+    //	NO = true;
+		checkDoNotAsk();
+		Configuration.put("AUTO_SWITCH_PROJECT", "no");
+        this.dispose();
+    }
+	
+}

--- a/src/net/sf/memoranda/ui/PreferencesDialog.java
+++ b/src/net/sf/memoranda/ui/PreferencesDialog.java
@@ -32,13 +32,18 @@ public class PreferencesDialog extends JDialog {
 	JRadioButton minHideRB = new JRadioButton();
 	JRadioButton standardTimeRB = new JRadioButton();
 	JRadioButton militaryTimeRB = new JRadioButton();
+	JRadioButton confirmSwitchRB = new JRadioButton();
+	JRadioButton declineSwitchRB = new JRadioButton();
 	ButtonGroup timeGroup = new ButtonGroup();
+	ButtonGroup projectGroup = new ButtonGroup();
 	JLabel jLabel7 = new JLabel();
 	JLabel jLabel8 = new JLabel();
+	JLabel jLabel9 = new JLabel();
 	ButtonGroup closeGroup = new ButtonGroup();
 	JLabel jLabel2 = new JLabel();
 	JRadioButton closeExitRB = new JRadioButton();
 	JCheckBox askConfirmChB = new JCheckBox();
+	JCheckBox askConfirmProjectChB = new JCheckBox();
 	JRadioButton closeHideRB = new JRadioButton();
 	JLabel jLabel3 = new JLabel();
 	ButtonGroup lfGroup = new ButtonGroup();
@@ -61,6 +66,7 @@ public class PreferencesDialog extends JDialog {
 	JButton cancelB = new JButton();
 	JPanel bottomPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 10));
 	JLabel lblExit = new JLabel();
+	JLabel lblSwitchProj = new JLabel();
 	JPanel soundPanel = new JPanel();
 	JCheckBox enableSoundCB = new JCheckBox();
 	BorderLayout borderLayout1 = new BorderLayout();
@@ -347,12 +353,28 @@ public class PreferencesDialog extends JDialog {
 		gbc.anchor = GridBagConstraints.WEST;
 		GeneralPanel.add(askConfirmChB, gbc);
 		
-		/*
-		 * Time format setting added to preferences
-		 * 
-		 * Victor Best 1/2016
-		 */
-
+		lblSwitchProj.setHorizontalAlignment(SwingConstants.RIGHT);
+		lblSwitchProj.setText(Local.getString("Auto-switch projects") + ":");
+		gbc = new GridBagConstraints();
+		gbc.gridx = 0;
+		gbc.gridy = 15;
+		gbc.insets = new Insets(2, 0, 10, 15);
+		gbc.anchor = GridBagConstraints.EAST;
+		GeneralPanel.add(lblSwitchProj, gbc);
+		askConfirmProjectChB.setSelected(true);
+		askConfirmProjectChB.setText(Local.getString("Ask confirmation"));
+		askConfirmProjectChB.addActionListener(new java.awt.event.ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				askConfirmProjectChB_actionPerformed(e);
+			}
+		});
+		gbc = new GridBagConstraints();
+		gbc.gridx = 1;
+		gbc.gridy = 15;
+		gbc.insets = new Insets(2, 0, 10, 10);
+		gbc.anchor = GridBagConstraints.WEST;
+		GeneralPanel.add(askConfirmProjectChB, gbc);
+		
 		gbc = new GridBagConstraints();
 		gbc.gridx = 0;
 		gbc.gridy = 16;
@@ -402,13 +424,57 @@ public class PreferencesDialog extends JDialog {
 		gbc.gridy = 18;
 		gbc.insets = new Insets(2, 0, 0, 15);
 		gbc.anchor = GridBagConstraints.EAST;
+		GeneralPanel.add(jLabel9, gbc);
+		jLabel9.setHorizontalAlignment(SwingConstants.RIGHT);
+		jLabel9.setText(Local.getString("Auto-switch to new projects:"));
+		
+		gbc = new GridBagConstraints();
+		gbc.gridx = 1;
+		gbc.gridy = 17;
+		gbc.insets = new Insets(2, 0, 0, 10);
+		gbc.anchor = GridBagConstraints.WEST;
+		GeneralPanel.add(confirmSwitchRB, gbc);
+		projectGroup.add(confirmSwitchRB);
+		confirmSwitchRB.setSelected(true);
+		confirmSwitchRB.setText(Local.getString("Yes"));
+		confirmSwitchRB.addActionListener(new java.awt.event.ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				confirmSwitchRB_actionPerformed(e);
+			}
+		});
+		gbc = new GridBagConstraints();
+		gbc.gridx = 1;
+		gbc.gridy = 18;
+		gbc.insets = new Insets(2, 0, 0, 10);
+		gbc.anchor = GridBagConstraints.WEST;
+		GeneralPanel.add(confirmSwitchRB, gbc);
+
+		projectGroup.add(declineSwitchRB);
+		declineSwitchRB.setText(Local.getString("No"));
+		declineSwitchRB.addActionListener(new java.awt.event.ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				declineSwitchRB_actionPerformed(e);
+			}
+		});
+		gbc = new GridBagConstraints();
+		gbc.gridx = 1;
+		gbc.gridy = 19;
+		gbc.insets = new Insets(2, 0, 0, 10);
+		gbc.anchor = GridBagConstraints.WEST;
+		GeneralPanel.add(declineSwitchRB, gbc);
+		
+		gbc = new GridBagConstraints();
+		gbc.gridx = 0;
+		gbc.gridy = 20;
+		gbc.insets = new Insets(2, 0, 0, 15);
+		gbc.anchor = GridBagConstraints.EAST;
 		GeneralPanel.add(jLabel8, gbc);
 		jLabel8.setHorizontalAlignment(SwingConstants.RIGHT);
 		jLabel8.setText(Local.getString("Task Progress Calculation:"));
 		
 		gbc = new GridBagConstraints();
 		gbc.gridx = 1;
-		gbc.gridy = 18;
+		gbc.gridy = 20;
 		gbc.insets = new Insets(7, 0, 10, 10);
 		gbc.anchor = GridBagConstraints.WEST;
 		GeneralPanel.add(calcButton, gbc);
@@ -540,7 +606,19 @@ public class PreferencesDialog extends JDialog {
 			standardTimeRB.setSelected(true);
 		else if (timeform.equalsIgnoreCase("military"))
 			militaryTimeRB.setSelected(true);
+		
+		String autoSelect = Configuration.get("AUTO_SWITCH_PROJECT").toString();
+		if (autoSelect.equalsIgnoreCase("yes"))
+			confirmSwitchRB.setSelected(true);
+		else if (autoSelect.equalsIgnoreCase("no"))
+			declineSwitchRB.setSelected(true);
 
+		String onNew = Configuration.get("ASK_ON_NEW").toString();
+		if (onNew.equalsIgnoreCase("yes"))
+			askConfirmProjectChB.setSelected(true);
+		else if (onNew.equalsIgnoreCase("no"))
+			askConfirmProjectChB.setSelected(false);
+		
 		enableCustomLF(false);
 		String lf = Configuration.get("LOOK_AND_FEEL").toString();
 		if (lf.equalsIgnoreCase("system"))
@@ -621,6 +699,11 @@ public class PreferencesDialog extends JDialog {
 		else
 			Configuration.put("TIME_FORMAT", "military");
 		
+		if (this.confirmSwitchRB.isSelected())
+			Configuration.put("AUTO_SWITCH_PROJECT", "yes");
+		else
+			Configuration.put("AUTO_SWITCH_PROJECT", "no");
+		
 		if (this.firstdow.isSelected())
 			Configuration.put("FIRST_DAY_OF_WEEK", "mon");
 		else
@@ -650,6 +733,11 @@ public class PreferencesDialog extends JDialog {
 			Configuration.put("ASK_ON_EXIT", "yes");
 		else
 			Configuration.put("ASK_ON_EXIT", "no");
+		
+		if (this.askConfirmProjectChB.isSelected())
+			Configuration.put("ASK_ON_NEW", "yes");
+		else
+			Configuration.put("ASK_ON_NEW", "no");
 
 		if (this.closeExitRB.isSelected())
 			Configuration.put("ON_CLOSE", "exit");
@@ -773,6 +861,19 @@ public class PreferencesDialog extends JDialog {
 	void militaryTimeRB_actionPerformed(ActionEvent e) {
 		//System.out.println("military time selected");	
 	}
+	
+	void confirmSwitchRB_actionPerformed(ActionEvent e) {
+			
+	}
+	
+	void declineSwitchRB_actionPerformed(ActionEvent e) {
+		
+	}
+	
+	void askConfirmProjectChB_actionPerformed(ActionEvent e) {
+		
+	}
+	
 
 	void askConfirmChB_actionPerformed(ActionEvent e) {
 

--- a/src/net/sf/memoranda/ui/ProjectDialog.java
+++ b/src/net/sf/memoranda/ui/ProjectDialog.java
@@ -31,6 +31,7 @@ import javax.swing.event.ChangeListener;
 import net.sf.memoranda.Project;
 import net.sf.memoranda.ProjectManager;
 import net.sf.memoranda.date.CalendarDate;
+import net.sf.memoranda.util.Configuration;
 import net.sf.memoranda.util.CurrentStorage;
 import net.sf.memoranda.util.Local;
 
@@ -57,6 +58,7 @@ public class ProjectDialog extends JDialog {
     JPanel bottomPanel = new JPanel();
     JButton okButton = new JButton();
     JButton cancelButton = new JButton();
+    static AppFrame frame = new AppFrame();
     
     public ProjectDialog(Frame frame, String title) {
         super(frame, title, true);
@@ -270,6 +272,7 @@ public class ProjectDialog extends JDialog {
     
     void okButton_actionPerformed(ActionEvent e) {
         CANCELLED = false;
+        frame.doNewProject();
         this.dispose();
     }
     
@@ -306,7 +309,7 @@ public class ProjectDialog extends JDialog {
         endCalFrame.show();
     }
     
-    public static void newProject() {
+    public static Project newProject() {
         ProjectDialog dlg = new ProjectDialog(null, Local.getString("New project"));
         
         Dimension dlgSize = dlg.getSize();
@@ -316,7 +319,7 @@ public class ProjectDialog extends JDialog {
         dlg.setLocation((frmSize.width - dlgSize.width) / 2 + loc.x, (frmSize.height - dlgSize.height) / 2 + loc.y);
         dlg.setVisible(true);
         if (dlg.CANCELLED)
-            return;
+            return null;
         String title = dlg.prTitleField.getText();
         CalendarDate startD = new CalendarDate((Date) dlg.startDate.getModel().getValue());
         CalendarDate endD = null;
@@ -326,5 +329,7 @@ public class ProjectDialog extends JDialog {
         /*if (dlg.freezeChB.isSelected())
             prj.freeze();*/
         CurrentStorage.get().storeProjectManager();
+        return prj;
     }
+    
 }

--- a/src/net/sf/memoranda/ui/ProjectsPanel.java
+++ b/src/net/sf/memoranda/ui/ProjectsPanel.java
@@ -43,8 +43,6 @@ import net.sf.memoranda.TaskList;
 import net.sf.memoranda.date.CalendarDate;
 import net.sf.memoranda.date.CurrentDate;
 import net.sf.memoranda.date.DateListener;
-import net.sf.memoranda.util.Context;
-import net.sf.memoranda.util.CurrentStorage;
 import net.sf.memoranda.util.*;
 
 /*$Id: ProjectsPanel.java,v 1.14 2005/01/04 09:59:22 pbielen Exp $*/
@@ -344,7 +342,15 @@ public class ProjectsPanel extends JPanel implements ExpandablePanel {
 	}
 
 	void ppNewProject_actionPerformed(ActionEvent e) {
-		ProjectDialog.newProject();
+		Project newProject = ProjectDialog.newProject();
+		
+		if (newProject != null){
+			String autoSelect = Configuration.get("AUTO_SWITCH_PROJECT").toString();
+			if (autoSelect.equalsIgnoreCase("yes")){
+				CurrentProject.set(newProject);
+			}
+		}
+			
 		prjTablePanel.updateUI();
 	}
 

--- a/src/net/sf/memoranda/util/resources/memoranda.default.properties
+++ b/src/net/sf/memoranda/util/resources/memoranda.default.properties
@@ -19,6 +19,9 @@ ON_MINIMIZE = normal
 # Confirm on exit if there are active events (yes* | no)
 ASK_ON_EXIT = yes
 
+# Confirm on switching to new projects
+ASK_ON_NEW = yes
+
 # Show splash screen at startup (yes* | no)
 SHOW_SPLASH = yes
 
@@ -32,6 +35,9 @@ PORT_NUMBER = 19432
 
 # Time format setting
 TIME_FORMAT = standard
+
+# Auto-Switch to new projects
+AUTO_SWITCH_PROJECT = yes
 
 CHECK_IF_ALREADY_STARTED = YES
 


### PR DESCRIPTION
Ok Team! Here is the functionality for auto switching to a newly created project.
- Added options in preferences to choose if to auto-switch to newly created projects (yes/no)
- Added option in preferences to enable/disable prompt for confirmation to switch to new  projects (check-box)
- Confirmation of auto-switching is shown by default until user checks "don't ask again" or sets it in preferences
- User preference is saved when "do not ask again is checked"
- Fully functional, project will switch (or not) based on user's preferences or response to prompt (if still enabled)
